### PR TITLE
Revert "Next development version"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.cloud</groupId>
 	<artifactId>spring-cloud-dataflow-build</artifactId>
-	<version>2.10.1-SNAPSHOT</version>
+	<version>2.10.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Spring Cloud Dataflow Build</name>
 	<description>Spring Cloud Dataflow Build, managing plugins and dependencies</description>
@@ -22,7 +22,7 @@
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<main.basedir>${basedir}</main.basedir>
 		<docs.main>${project.artifactId}</docs.main>
-		<spring-cloud-dataflow-build.version>2.10.1-SNAPSHOT</spring-cloud-dataflow-build.version>
+		<spring-cloud-dataflow-build.version>2.10.0-SNAPSHOT</spring-cloud-dataflow-build.version>
 		<!-- Keep spring boot version in sync between spring-cloud-dataflow-build and spring-boot-dependencies (parent and properties) -->
 		<spring-boot.version>2.6.6</spring-boot.version>
 		<docs.resources.dir>${project.build.directory}/build-docs</docs.resources.dir>
@@ -99,7 +99,7 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dataflow-build-dependencies</artifactId>
-				<version>2.10.1-SNAPSHOT</version>
+				<version>2.10.0-SNAPSHOT</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/spring-cloud-dataflow-build-dependencies/pom.xml
+++ b/spring-cloud-dataflow-build-dependencies/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.cloud</groupId>
 	<artifactId>spring-cloud-dataflow-build-dependencies</artifactId>
-	<version>2.10.1-SNAPSHOT</version>
+	<version>2.10.0-SNAPSHOT</version>
 	<name>Spring Cloud Dataflow Build Dependencies</name>
 	<packaging>pom</packaging>
 	<description>Spring Cloud Dataflow Build Dependencies: an internal BOM for use with Spring

--- a/spring-cloud-dataflow-build-tools/pom.xml
+++ b/spring-cloud-dataflow-build-tools/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-dataflow-build</artifactId>
-		<version>2.10.1-SNAPSHOT</version>
+		<version>2.10.0-SNAPSHOT</version>
 	</parent>
 	<dependencies>
 		<dependency>

--- a/spring-cloud-dataflow-dependencies-parent/pom.xml
+++ b/spring-cloud-dataflow-dependencies-parent/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.cloud</groupId>
-	<version>2.10.1-SNAPSHOT</version>
+	<version>2.10.0-SNAPSHOT</version>
 	<artifactId>spring-cloud-dataflow-dependencies-parent</artifactId>
 	<packaging>pom</packaging>
 	<name>Spring Cloud Dataflow Dependencies Parent</name>


### PR DESCRIPTION
This reverts commit aa09f7e448e5179c4bc3dee5aa0f97f0e61db09d.

The "Next Dev Version Controller" GH action was run from SCDF accidentally on "main" branch. It was quickly stopped but not before it updated these files to the next dev version. This undoes that. 

**Context from Slack**
> Yeh - looks like I kicked it off on main…. realized it was main…. killed the main controlller (it only made it to SCDF-build)… did not clean up the side-effects. This was that run from controller (notice only 2 steps in the zoo context) https://github.com/spring-cloud/spring-cloud-dataflow/runs/5713489085?check_suite_focus=true#step:2:117
This is the one for 2.9.x - notice its zoo context went through all the things.. https://github.com/spring-cloud/spring-cloud-dataflow/runs/5713671791?check_suite_focus=true#step:2:98




